### PR TITLE
RKUtils 3.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,11 @@ DerivedData/
 .swiftpm/
 .netrc
 
+# Maintainer-only scripts (contributors don't need these)
+scripts/
+
+# Documentation builds (generated, deploy manually, don't commit)
+docs-output/
+
 # Claude AI
-CLAUDE.md
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ docs-output/
 
 # Claude AI
 .claude/
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.1.0] - 2026-04-24
+
+### Added
+
+- **`URL.readFromFile()`** — new Foundation extension to read file contents directly from a URL. Replaces the misplaced `String.readFromFile(fileURL:)` that was removed in this version.
+- **`abbreviated(locale:decimalPlaces:)`** — `decimalPlaces` parameter added to both `Double` and `Int`. Controls how many decimal digits appear in formatted output (default: `1`).
+- **`Int.inWords(locale:)`** now delegates to `Double.inWords(locale:)` — single implementation, consistent behaviour.
+
+### Changed
+
+- **`Int.abbreviated(locale:decimalPlaces:)`** delegates to `Double.abbreviated(locale:decimalPlaces:)` — eliminates duplicate logic and fixes the negative-number bug in the old Int implementation.
+- **`Double.abbreviated()`** uses `NumberFormatter` — trailing zeros suppressed by default (e.g. `1000` → `"1K"`, not `"1.0K"`).
+
+### Removed
+
+- **`String.readFromFile(fileURL:)`** — phantom API where `self` was never used. Replaced by `URL.readFromFile()`.
+
+---
+
 ## [3.0.0] - 2025-01-08
 
 ### 🎉 Major Release - Single Target Architecture & Comprehensive Documentation
@@ -299,7 +318,8 @@ import RKUtils        // All platforms
 - [Swift Package Index](https://swiftpackageindex.com/TheRakiburKhan/RKUtils)
 - [Report Issues](https://github.com/TheRakiburKhan/RKUtils/issues)
 
-[Unreleased]: https://github.com/TheRakiburKhan/RKUtils/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/TheRakiburKhan/RKUtils/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/TheRakiburKhan/RKUtils/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/TheRakiburKhan/RKUtils/releases/tag/v3.0.0
 [2.1.1]: https://github.com/TheRakiburKhan/RKUtils/releases/tag/v2.1.1
 [2.1.0]: https://github.com/TheRakiburKhan/RKUtils/releases/tag/v2.1.0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/TheRakiburKhan/RKUtils.git", from: "3.0.0")
+    .package(url: "https://github.com/TheRakiburKhan/RKUtils.git", from: "3.1.0")
 ]
 ```
 
@@ -34,7 +34,7 @@ dependencies: [
 
 1. **File > Add Package Dependencies...**
 2. Enter: `https://github.com/TheRakiburKhan/RKUtils.git`
-3. Select version **3.0.0+** and add to your target
+3. Select version **3.1.0+** and add to your target
 
 ### Target Configuration
 

--- a/Sources/RKUtils/Foundation/Double.swift
+++ b/Sources/RKUtils/Foundation/Double.swift
@@ -214,14 +214,15 @@ public extension Double {
 
      - Parameters:
         - calendar: Calendar to be used. Default is .autoupdatingCurrent
+        - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
         - units: Allowed time components.
         - style: Output format style.
         - context: Formatting context.
 
      - Returns: A time-formatted string.
      */
-    func secondsToTime(calendar: Calendar = .autoupdatingCurrent, units: NSCalendar.Unit = [.hour, .minute, .second], style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
-        let formatter = dateComponentsFormatter(calendar: calendar, units: units, style: style, context: context)
+    func secondsToTime(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, units: NSCalendar.Unit = [.hour, .minute, .second], style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
+        let formatter = dateComponentsFormatter(calendar: calendar, locale: locale, units: units, style: style, context: context)
 
         return formatter.string(from: self) ?? "\(self)s"
     }
@@ -231,14 +232,15 @@ public extension Double {
 
      - Parameters:
         - calendar: Calendar to be used. Default is .autoupdatingCurrent
+        - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
         - style: Units style.
         - context: Formatting context.
 
      - Returns: A day-formatted string.
      */
-    func day(calendar: Calendar = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
+    func day(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
         let components = DateComponents(day: Int(self))
-        let formatter = dateComponentsFormatter(calendar: calendar, units: [.day], style: style, context: context)
+        let formatter = dateComponentsFormatter(calendar: calendar, locale: locale, units: [.day], style: style, context: context)
         return formatter.string(from: components) ?? toLocal()
     }
 
@@ -247,14 +249,15 @@ public extension Double {
 
      - Parameters:
         - calendar: Calendar to be used. Default is .autoupdatingCurrent
+        - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
         - style: Units style.
         - context: Formatting context.
 
      - Returns: A month-formatted string.
      */
-    func month(calendar: Calendar = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
+    func month(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
         let components = DateComponents(month: Int(self))
-        let formatter = dateComponentsFormatter(calendar: calendar, units: [.month], style: style, context: context)
+        let formatter = dateComponentsFormatter(calendar: calendar, locale: locale, units: [.month], style: style, context: context)
         return formatter.string(from: components) ?? toLocal()
     }
 
@@ -263,14 +266,15 @@ public extension Double {
 
      - Parameters:
         - calendar: Calendar to be used. Default is .autoupdatingCurrent
+        - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
         - style: Units style.
         - context: Formatting context.
 
      - Returns: A year-formatted string.
      */
-    func year(calendar: Calendar = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
+    func year(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
         let components = DateComponents(year: Int(self))
-        let formatter = dateComponentsFormatter(calendar: calendar, units: [.year], style: style, context: context)
+        let formatter = dateComponentsFormatter(calendar: calendar, locale: locale, units: [.year], style: style, context: context)
         return formatter.string(from: components) ?? toLocal()
     }
 }
@@ -457,9 +461,10 @@ private extension Double {
     }
     
     #if canImport(Darwin)
-    func dateComponentsFormatter(calendar: Calendar, units: NSCalendar.Unit, style: DateComponentsFormatter.UnitsStyle, context: Formatter.Context) -> DateComponentsFormatter {
+    func dateComponentsFormatter(calendar: Calendar, locale: Locale, units: NSCalendar.Unit, style: DateComponentsFormatter.UnitsStyle, context: Formatter.Context) -> DateComponentsFormatter {
         let formatter = DateComponentsFormatter()
         formatter.calendar = calendar
+        formatter.calendar?.locale = locale
         formatter.allowedUnits = units
         formatter.unitsStyle = style
         formatter.formattingContext = context

--- a/Sources/RKUtils/Foundation/Double.swift
+++ b/Sources/RKUtils/Foundation/Double.swift
@@ -12,7 +12,7 @@ import Foundation
 // MARK: Number Formatting
 public extension Double {
     /**
-    Converts the Double to a localized string using NumberFormatter.
+     Converts the Double to a localized string using NumberFormatter.
      
      - Parameters:
         - minFraction: Minimum number of digits after the decimal point.
@@ -27,8 +27,8 @@ public extension Double {
     }
     
     /**
-    Converts the Double into scientific notation format.
-    
+     Converts the Double into scientific notation format.
+     
      - Parameters:
         - minFraction: Minimum digits after the decimal point.
         - maxFraction: Maximum digits after the decimal point.
@@ -50,8 +50,8 @@ public extension Double {
      
      - Returns: A percentage-formatted string.
      */
-     func percentage(minFraction: Int? = nil, maxFraction: Int? = nil, groupSize: Int? = nil) -> String {
-         let value = self / 100.0
+    func percentage(minFraction: Int? = nil, maxFraction: Int? = nil, groupSize: Int? = nil) -> String {
+        let value = self / 100.0
         let formatter = numberFormatter(minFraction: minFraction, maxFraction: maxFraction, numberStyle: .percent, groupSize: groupSize)
         return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f%%", value * 100)
     }
@@ -117,22 +117,30 @@ public extension Double {
     
     /**
      Converts the Double into abbreviated string (e.g., 1.2K, 5.6M).
-     
-     - Returns: A shortened string representation with suffixes.
+
+     - Parameters:
+        - locale: Locale for decimal separator formatting (default is `.current`).
+        - decimalPlaces: Maximum number of decimal digits to show (default is `1`).
+
+     - Returns: A shortened string representation with suffixes. Handles negative values.
      */
-    func abbreviated() -> String {
+    func abbreviated(locale: Locale = .current, decimalPlaces: Int = 1) -> String {
         let absValue = abs(self)
         let sign = self < 0 ? "-" : ""
-        
+
+        let formatter = NumberFormatter()
+        formatter.maximumFractionDigits = decimalPlaces
+        formatter.locale = locale
+
+        func format(_ value: Double) -> String {
+            formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+        }
+
         switch absValue {
-            case 1_000_000_000...:
-                return "\(sign)\((absValue / 1_000_000_000).roundedString(toPlaces: 1))B"
-            case 1_000_000...:
-                return "\(sign)\((absValue / 1_000_000).roundedString(toPlaces: 1))M"
-            case 1_000...:
-                return "\(sign)\((absValue / 1_000).roundedString(toPlaces: 1))K"
-            default:
-                return "\(sign)\(roundedString(toPlaces: 1))"
+            case 1_000_000_000...: return "\(sign)\(format(absValue / 1_000_000_000))B"
+            case 1_000_000...:    return "\(sign)\(format(absValue / 1_000_000))M"
+            case 1_000...:        return "\(sign)\(format(absValue / 1_000))K"
+            default:              return "\(sign)\(format(absValue))"
         }
     }
 }
@@ -142,62 +150,62 @@ public extension Double {
 public extension Double {
     /**
      Formats a Double as a distance value (e.g., meters, kilometers).
-
+     
      - Parameters:
         - baseUnit: Unit of measurement (default is meters).
         - unitStyle: Display style (e.g., .short, .medium).
         - minFraction: Minimum fraction digits.
         - maxFraction: Maximum fraction digits.
         - groupSize: Optional grouping size.
-
+     
      - Returns: A localized distance string.
      */
     func distance(baseUnit: UnitLength = .meters, unitStyle: Formatter.UnitStyle = .medium, minFraction: Int? = nil, maxFraction: Int? = nil, groupSize: Int? = nil) -> String {
         return measurementString(unit: baseUnit, unitStyle: unitStyle, minFraction: minFraction, maxFraction: maxFraction, groupSize: groupSize)
     }
-
+    
     /**
      Formats the Double as a duration (e.g., minutes, hours).
-
+     
      - Parameters:
         - baseUnit: Duration unit (default is `.minutes`).
         - unitStyle: Formatter style.
         - minFraction: Minimum fraction digits.
         - maxFraction: Maximum fraction digits.
         - groupSize: Optional grouping size.
-
+     
      - Returns: A formatted duration string.
      */
     func time(baseUnit: UnitDuration = .minutes, unitStyle: Formatter.UnitStyle = .medium, minFraction: Int? = nil, maxFraction: Int? = nil, groupSize: Int? = nil) -> String {
         return measurementString(unit: baseUnit, unitStyle: unitStyle, minFraction: minFraction, maxFraction: maxFraction, groupSize: groupSize)
     }
-
+    
     /**
      Formats the Double as a temperature value in Kelvin.
-
+     
      - Parameters:
         - baseUnit: Temperature Unit (default is `.kelvin`).
         - unitStyle: Display style.
         - minFraction: Minimum fraction digits.
         - maxFraction: Maximum fraction digits.
         - groupSize: Optional grouping size.
-
+     
      - Returns: A temperature-formatted string.
      */
     func temperature(baseUnit: UnitTemperature = .kelvin, unitStyle: Formatter.UnitStyle = .medium, minFraction: Int? = nil, maxFraction: Int? = nil, groupSize: Int? = nil) -> String {
         return measurementString(unit: baseUnit, unitStyle: unitStyle, minFraction: minFraction, maxFraction: maxFraction, groupSize: groupSize)
     }
-
+    
     /**
      Formats the Double as a speed value in metersPerSecond.
-
+     
      - Parameters:
         - baseUnit: Speed Unit (default is `.metersPerSecond`).
         - unitStyle: Display style.
         - minFraction: Minimum fraction digits.
         - maxFraction: Maximum fraction digits.
         - groupSize: Optional grouping size.
-
+     
      - Returns: A speed-formatted string.
      */
     func speed(baseUnit: UnitSpeed = .metersPerSecond, unitStyle: Formatter.UnitStyle = .medium, minFraction: Int? = nil, maxFraction: Int? = nil, groupSize: Int? = nil) -> String {
@@ -211,71 +219,65 @@ public extension Double {
 public extension Double {
     /**
      Converts seconds into a readable time format (e.g., "1h 3m").
-
+     
      - Parameters:
         - calendar: Calendar to be used. Default is .autoupdatingCurrent
         - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
         - units: Allowed time components.
         - style: Output format style.
         - context: Formatting context.
-
+     
      - Returns: A time-formatted string.
      */
     func secondsToTime(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, units: NSCalendar.Unit = [.hour, .minute, .second], style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
         let formatter = dateComponentsFormatter(calendar: calendar, locale: locale, units: units, style: style, context: context)
-
+        
         return formatter.string(from: self) ?? "\(self)s"
     }
-
+    
     /**
      Converts a number to a day count string.
-
+     
      - Parameters:
         - calendar: Calendar to be used. Default is .autoupdatingCurrent
         - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
         - style: Units style.
         - context: Formatting context.
-
+     
      - Returns: A day-formatted string.
      */
     func day(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
-        let components = DateComponents(day: Int(self))
-        let formatter = dateComponentsFormatter(calendar: calendar, locale: locale, units: [.day], style: style, context: context)
-        return formatter.string(from: components) ?? toLocal()
+        Int(self).day(calendar: calendar, locale: locale, style: style, context: context)
     }
-
+    
     /**
      Converts a number to a month count string.
-
+     
      - Parameters:
         - calendar: Calendar to be used. Default is .autoupdatingCurrent
         - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
         - style: Units style.
         - context: Formatting context.
-
+     
      - Returns: A month-formatted string.
      */
     func month(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
-        let components = DateComponents(month: Int(self))
-        let formatter = dateComponentsFormatter(calendar: calendar, locale: locale, units: [.month], style: style, context: context)
-        return formatter.string(from: components) ?? toLocal()
+        Int(self).month(calendar: calendar, locale: locale, style: style, context: context)
     }
-
+    
     /**
      Converts a number to a year count string.
-
+     
      - Parameters:
         - calendar: Calendar to be used. Default is .autoupdatingCurrent
         - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
         - style: Units style.
         - context: Formatting context.
-
+     
      - Returns: A year-formatted string.
      */
     func year(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
-        let components = DateComponents(year: Int(self))
-        let formatter = dateComponentsFormatter(calendar: calendar, locale: locale, units: [.year], style: style, context: context)
-        return formatter.string(from: components) ?? toLocal()
+        Int(self).year(calendar: calendar, locale: locale, style: style, context: context)
     }
 }
 #else
@@ -289,7 +291,7 @@ public extension Double {
         let hours = totalSeconds / 3600
         let minutes = (totalSeconds % 3600) / 60
         let seconds = totalSeconds % 60
-
+        
         // If custom format provided, use it
         if let customFormat = format {
             var result = customFormat
@@ -301,7 +303,7 @@ public extension Double {
             result = result.replacingOccurrences(of: "%02s", with: String(format: "%02d", seconds))
             return result
         }
-
+        
         // Default format
         if hours > 0 {
             return String(format: "%d:%02d:%02d", hours, minutes, seconds)
@@ -309,23 +311,20 @@ public extension Double {
             return String(format: "%d:%02d", minutes, seconds)
         }
     }
-
+    
     // Linux fallback - basic formatting (style/context parameters not available on Linux)
     func day() -> String {
-        let days = Int(self)
-        return "\(days) day\(days == 1 ? "" : "s")"
+        Int(self).day()
     }
-
+    
     // Linux fallback - basic formatting (style/context parameters not available on Linux)
     func month() -> String {
-        let months = Int(self)
-        return "\(months) month\(months == 1 ? "" : "s")"
+        Int(self).month()
     }
-
+    
     // Linux fallback - basic formatting (style/context parameters not available on Linux)
     func year() -> String {
-        let years = Int(self)
-        return "\(years) year\(years == 1 ? "" : "s")"
+        Int(self).year()
     }
 }
 #endif
@@ -460,7 +459,7 @@ private extension Double {
         return formatter
     }
     
-    #if canImport(Darwin)
+#if canImport(Darwin)
     func dateComponentsFormatter(calendar: Calendar, locale: Locale, units: NSCalendar.Unit, style: DateComponentsFormatter.UnitsStyle, context: Formatter.Context) -> DateComponentsFormatter {
         let formatter = DateComponentsFormatter()
         formatter.calendar = calendar
@@ -470,15 +469,15 @@ private extension Double {
         formatter.formattingContext = context
         return formatter
     }
-
+    
     func measurementString<T: Dimension>(unit: T, unitStyle: Formatter.UnitStyle, minFraction: Int?, maxFraction: Int?, groupSize: Int?) -> String {
         let measurement = Measurement(value: self, unit: unit)
         let formatter = MeasurementFormatter()
         formatter.unitStyle = unitStyle
         formatter.unitOptions = .naturalScale
         formatter.numberFormatter = numberFormatter(minFraction: minFraction, maxFraction: maxFraction, groupSize: groupSize)
-
+        
         return formatter.string(from: measurement)
     }
-    #endif
+#endif
 }

--- a/Sources/RKUtils/Foundation/Int.swift
+++ b/Sources/RKUtils/Foundation/Int.swift
@@ -10,49 +10,6 @@ import Foundation
 
 public extension Int {
     /**
-     Creates a `NumberFormatter` with customizable style, grouping, and locale.
-     
-     - Parameters:
-        - numberStyle: The formatting style to apply (e.g., `.decimal`, `.spellOut`).
-        - groupSize: The digit group size (e.g., 3 for thousands).
-        - groupSeparator: Whether to use digit group separators (e.g., "1,000").
-        - locale: The locale to use (default is `.current`).
-     
-     - Returns: A configured `NumberFormatter`.
-    */
-    private func numberFormatter( numberStyle: NumberFormatter.Style? = nil, groupSize: Int? = nil, groupSeparator: Bool? = nil, locale: Locale = .current) -> NumberFormatter {
-        let formatter = NumberFormatter()
-        formatter.maximumFractionDigits = 0
-        formatter.locale = locale
-        
-        if let numberStyle = numberStyle {
-            formatter.numberStyle = numberStyle
-        }
-        
-        if let groupSize = groupSize {
-            formatter.groupingSize = groupSize
-        }
-        
-        if let useGroupSeparator = groupSeparator {
-            formatter.usesGroupingSeparator = useGroupSeparator
-        }
-        
-        return formatter
-    }
-    
-    #if canImport(Darwin)
-    private func dateComponentsFormatter(units: NSCalendar.Unit, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> DateComponentsFormatter {
-        let formatter = DateComponentsFormatter()
-
-        formatter.allowedUnits = units
-        formatter.unitsStyle = style
-        formatter.formattingContext = context
-
-        return formatter
-    }
-    #endif
-    
-    /**
      Converts the Double to a percentage string (e.g., "25%").
      
      - Parameters:
@@ -63,9 +20,7 @@ public extension Int {
      - Returns: A percentage-formatted string.
      */
     func percentage(minFraction: Int? = nil, maxFraction: Int? = nil, groupSize: Int? = nil) -> String {
-        let value = Double(self) / 100.0
-        let formatter = numberFormatter(numberStyle: .percent, groupSize: groupSize)
-        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f%%", value * 100)
+        Double(self).percentage(minFraction: minFraction, maxFraction: maxFraction, groupSize: groupSize)
     }
     
     /**
@@ -77,7 +32,7 @@ public extension Int {
      - Returns: A localized string representation of the number.
     */
     func toLocal(locale: Locale = .current) -> String {
-        let formatter = numberFormatter(numberStyle: .decimal, locale: locale)
+        let formatter = numberFormatter(locale: locale, numberStyle: .decimal)
         return formatter.string(from: NSNumber(value: self)) ?? "\(self)"
     }
     
@@ -95,7 +50,7 @@ public extension Int {
      - Returns: A formatted string representing the rounded number with optional suffix.
      */
     func intervalDescription(interval: Int, suffix: String = "+", groupSeparator: Bool = false, locale: Locale = .current) -> String {
-        let formatter = numberFormatter(numberStyle: .decimal, groupSeparator: groupSeparator, locale: locale)
+        let formatter = numberFormatter(locale: locale, numberStyle: .decimal, groupSeparator: groupSeparator)
         
         let absoluteInterval = abs(interval)
         let absSelf = abs(self)
@@ -132,7 +87,7 @@ public extension Int {
      - Returns: An array of strings representing each digit.
     */
     func digitNames(locale: Locale = .current, fallbackToEnglish: Bool = true) -> [String] {
-        let formatter = numberFormatter(numberStyle: .spellOut, locale: locale)
+        let formatter = numberFormatter(locale: locale, numberStyle: .spellOut)
         
         let digits: [String] = String(self).compactMap { char -> String? in
             guard let digit = Int(String(char)) else { return nil }
@@ -153,8 +108,7 @@ public extension Int {
      - Returns: A string with the number written in words.
      */
     func inWords(locale: Locale = .current) -> String {
-        let formatter = numberFormatter(numberStyle: .spellOut, locale: locale)
-        return formatter.string(from: NSNumber(value: self)) ?? "\(self)"
+        Double(self).inWords(locale: locale)
     }
     
     /**
@@ -222,62 +176,101 @@ public extension Int {
     
     /**
      Returns a shortened, human-readable abbreviation of large numbers.
-     
+
      For example: `1_200` → `"1.2K"`, `1_500_000` → `"1.5M"`
-     
+
      - Parameters:
         - locale: The locale to use for decimal formatting.
-     
+        - decimalPlaces: Maximum number of decimal digits to show (default is `1`).
+
      - Returns: An abbreviated string with suffix (K, M, B).
     */
-    func abbreviated(locale: Locale = .current) -> String {
-        let num = Double(self)
-        let thousand = 1_000.0
-        let million = 1_000_000.0
-        let billion = 1_000_000_000.0
-        
-        let formatter = NumberFormatter()
-        formatter.maximumFractionDigits = 1
-        formatter.locale = locale
-        
-        switch num {
-            case 0..<thousand:
-                return "\(self)"
-            case thousand..<million:
-                return "\(formatter.string(from: NSNumber(value: num / thousand)) ?? "")K"
-            case million..<billion:
-                return "\(formatter.string(from: NSNumber(value: num / million)) ?? "")M"
-            default:
-                return "\(formatter.string(from: NSNumber(value: num / billion)) ?? "")B"
-        }
+    func abbreviated(locale: Locale = .current, decimalPlaces: Int = 1) -> String {
+        Double(self).abbreviated(locale: locale, decimalPlaces: decimalPlaces)
     }
 }
 
 #if canImport(Darwin)
 public extension Int {
-    func day(style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
+    /**
+     Converts seconds into a readable time format (e.g., "1h 3m").
+     
+     - Parameters:
+        - calendar: Calendar to be used. Default is .autoupdatingCurrent
+        - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
+        - units: Allowed time components.
+        - style: Output format style.
+        - context: Formatting context.
+     
+     - Returns: A time-formatted string.
+     */
+    func secondsToTime(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, units: NSCalendar.Unit = [.hour, .minute, .second], style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
+        Double(self).secondsToTime(calendar: calendar, locale: locale, units: units, style: style, context: context)
+    }
+    
+    /**
+     Converts a number to a day count string.
+     
+     - Parameters:
+        - calendar: Calendar to be used. Default is .autoupdatingCurrent
+        - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
+        - style: Units style.
+        - context: Formatting context.
+     
+     - Returns: A day-formatted string.
+     */
+    func day(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
         let components = DateComponents(day: self)
-        let formatter = dateComponentsFormatter(units: [.day], style: style, context: context)
+        let formatter = dateComponentsFormatter(calendar: .autoupdatingCurrent, locale: .autoupdatingCurrent, units: [.day], style: style, context: context)
 
         return formatter.string(from: components) ?? self.toLocal()
     }
-
-    func month(style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
+    
+    /**
+     Converts a number to a month count string.
+     
+     - Parameters:
+        - calendar: Calendar to be used. Default is .autoupdatingCurrent
+        - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
+        - style: Units style.
+        - context: Formatting context.
+     
+     - Returns: A month-formatted string.
+     */
+    func month(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
         let components = DateComponents(month: self)
-        let formatter = dateComponentsFormatter(units: [.month], style: style, context: context)
+        let formatter = dateComponentsFormatter(calendar: .autoupdatingCurrent, locale: .autoupdatingCurrent, units: [.month], style: style, context: context)
 
         return formatter.string(from: components) ?? self.toLocal()
     }
-
-    func year(style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
+    
+    /**
+     Converts a number to a year count string.
+     
+     - Parameters:
+        - calendar: Calendar to be used. Default is .autoupdatingCurrent
+        - locale: Locale for language and region formatting. Default is .autoupdatingCurrent
+        - style: Units style.
+        - context: Formatting context.
+     
+     - Returns: A year-formatted string.
+     */
+    func year(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, style: DateComponentsFormatter.UnitsStyle = .abbreviated, context: Formatter.Context = .listItem) -> String {
         let components = DateComponents(year: self)
-        let formatter = dateComponentsFormatter(units: [.year], style: style, context: context)
+        let formatter = dateComponentsFormatter(calendar: .autoupdatingCurrent, locale: .autoupdatingCurrent, units: [.year], style: style, context: context)
 
         return formatter.string(from: components) ?? self.toLocal()
     }
 }
 #else
 public extension Int {
+    // Linux fallback - basic formatting (style/context parameters not available on Linux)
+    // Format placeholders: %h (hours), %m (minutes), %s (seconds)
+    // Use %02d style for zero-padding: e.g., "%h:%02m:%02s" -> "1:05:09"
+    func secondsToTime(format: String? = nil) -> String {
+        Double(self).secondsToTime(format: format)
+    }
+    
     // Linux fallback - basic formatting (style/context parameters not available on Linux)
     func day() -> String {
         return "\(self) day\(self == 1 ? "" : "s")"
@@ -354,4 +347,38 @@ public extension Int {
     func toPositiveSuffix(interval: Int, suffix: String = "+", groupSeparator: Bool = false, locale: Locale = .current) -> String {
        return intervalDescription(interval: interval, suffix: suffix, groupSeparator: groupSeparator, locale: locale)
     }
+}
+
+// MARK: - Private Helpers
+private extension Int {
+    func numberFormatter(locale: Locale = .current, numberStyle: NumberFormatter.Style? = nil, groupSize: Int? = nil, groupSeparator: Bool? = nil) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        
+        if let style = numberStyle {
+            formatter.numberStyle = style
+        }
+        
+        if let group = groupSeparator {
+            formatter.usesGroupingSeparator = group
+        }
+        
+        if let size = groupSize {
+            formatter.groupingSize = size
+        }
+        
+        return formatter
+    }
+    
+#if canImport(Darwin)
+    func dateComponentsFormatter(calendar: Calendar, locale: Locale, units: NSCalendar.Unit, style: DateComponentsFormatter.UnitsStyle, context: Formatter.Context) -> DateComponentsFormatter {
+        let formatter = DateComponentsFormatter()
+        formatter.calendar = calendar
+        formatter.calendar?.locale = locale
+        formatter.allowedUnits = units
+        formatter.unitsStyle = style
+        formatter.formattingContext = context
+        return formatter
+    }
+#endif
 }

--- a/Sources/RKUtils/Foundation/String.swift
+++ b/Sources/RKUtils/Foundation/String.swift
@@ -117,35 +117,7 @@ public extension String {
         return self.range(of: emailRegex, options: [.regularExpression, .caseInsensitive]) != nil
     }
 
-    /**
-     Reads the contents of a text file into a string.
 
-     - Parameter fileURL: The URL of the file to read. If `nil`, returns `nil`.
-
-     - Returns: The file contents as a UTF-8 encoded string, or `nil` if reading fails.
-
-     - Example:
-     ```swift
-     let fileURL = URL(fileURLWithPath: "/path/to/file.txt")
-     let content = "".readFromFile(fileURL: fileURL)
-     ```
-
-     - Note: Errors are printed to console with `debugPrint`.
-     */
-    func readFromFile(fileURL: URL?) -> String? {
-        if let url = fileURL {
-            //reading
-            do {
-                let text = try String(contentsOf: url, encoding: .utf8)
-                return text
-            } catch {
-                print("Error:: Cant read file \(String(describing: fileURL))")
-                debugPrint(error)
-            }
-        }
-
-        return nil
-    }
 
     /**
      Writes the string to a file at the specified URL.

--- a/Sources/RKUtils/Foundation/URL.swift
+++ b/Sources/RKUtils/Foundation/URL.swift
@@ -1,0 +1,34 @@
+//
+//  URL.swift
+//  RKUtils
+//
+//
+//  Created by Rakibur Khan on 2/4/24.
+//
+
+import Foundation
+
+public extension URL {
+    /**
+     Reads the contents of this file URL as a UTF-8 encoded string.
+
+     - Returns: The file contents as a string, or `nil` if reading fails.
+
+     - Example:
+     ```swift
+     let fileURL = URL(fileURLWithPath: "/path/to/file.txt")
+     let content = fileURL.readFromFile()
+     ```
+
+     - Note: Errors are printed to console with `debugPrint`.
+     */
+    func readFromFile() -> String? {
+        do {
+            return try String(contentsOf: self, encoding: .utf8)
+        } catch {
+            print("Error:: Cant read file \(self)")
+            debugPrint(error)
+            return nil
+        }
+    }
+}

--- a/Sources/RKUtils/RKUtils.docc/Extension/Double.md
+++ b/Sources/RKUtils/RKUtils.docc/Extension/Double.md
@@ -211,7 +211,7 @@ Format numbers with localization and styling.
 - ``Double/percentage(minFraction:maxFraction:groupSize:)``
 - ``Double/currency(code:symbol:minFraction:maxFraction:groupSize:)``
 - ``Double/inWords(locale:)``
-- ``Double/abbreviated()``
+- ``Double/abbreviated(locale:decimalPlaces:)``
 - ``Double/toPositiveSuffix(interval:groupSeparator:)``
 
 ### Measurement Formatting
@@ -227,10 +227,10 @@ Format physical measurements with units (Apple platforms only).
 
 Convert numbers to time and date component strings.
 
-- ``Double/secondsToTime(calendar:units:style:context:)``
-- ``Double/day(calendar:style:context:)``
-- ``Double/month(calendar:style:context:)``
-- ``Double/year(calendar:style:context:)``
+- ``Double/secondsToTime(calendar:locale:units:style:context:)``
+- ``Double/day(calendar:locale:style:context:)``
+- ``Double/month(calendar:locale:style:context:)``
+- ``Double/year(calendar:locale:style:context:)``
 
 ### Mathematical Operations
 

--- a/Sources/RKUtils/RKUtils.docc/Extension/Int.md
+++ b/Sources/RKUtils/RKUtils.docc/Extension/Int.md
@@ -238,7 +238,7 @@ Format integers with localization and abbreviations.
 
 - ``Int/toLocal(locale:)``
 - ``Int/percentage(minFraction:maxFraction:groupSize:)``
-- ``Int/abbreviated(locale:)``
+- ``Int/abbreviated(locale:decimalPlaces:)``
 - ``Int/intervalDescription(interval:suffix:groupSeparator:locale:)``
 
 ### Word Formatting
@@ -261,9 +261,9 @@ Convert numbers to time strings and components.
 
 - ``Int/timeString``
 - ``Int/secondsToMinutesSeconds``
-- ``Int/day(style:context:)``
-- ``Int/month(style:context:)``
-- ``Int/year(style:context:)``
+- ``Int/day(calendar:locale:style:context:)``
+- ``Int/month(calendar:locale:style:context:)``
+- ``Int/year(calendar:locale:style:context:)``
 
 ### Utility Operations
 

--- a/Sources/RKUtils/RKUtils.docc/Extension/String.md
+++ b/Sources/RKUtils/RKUtils.docc/Extension/String.md
@@ -73,9 +73,8 @@ Encode strings to Base64 format for secure transmission or storage.
 
 ### File Operations
 
-Read from and write to files on disk.
+Write string content to a file on disk.
 
-- ``String/readFromFile(fileURL:)``
 - ``String/writeToFile(saveLocation:)``
 
 ## See Also

--- a/Sources/RKUtils/RKUtils.docc/Extension/URL.md
+++ b/Sources/RKUtils/RKUtils.docc/Extension/URL.md
@@ -1,0 +1,26 @@
+# ``RKUtils/Foundation/URL``
+
+File reading utilities for URL.
+
+## Overview
+
+URL extensions in RKUtils provide simple file I/O on top of Foundation's `URL` type. Reading a file is expressed directly on the URL itself, keeping call sites clean and removing the need for a throwaway string receiver.
+
+```swift
+let fileURL = URL(fileURLWithPath: "/path/to/file.txt")
+if let content = fileURL.readFromFile() {
+    print(content)
+}
+```
+
+## Topics
+
+### File Operations
+
+Read file contents directly from the URL.
+
+- ``URL/readFromFile()``
+
+## See Also
+
+- ``RKUtils/Swift/String``

--- a/Sources/RKUtils/RKUtils.docc/Migration-Guide.md
+++ b/Sources/RKUtils/RKUtils.docc/Migration-Guide.md
@@ -338,11 +338,11 @@ All public APIs remain **100% compatible**. The following code works identically
 
 ```swift
 // String extensions
-"test@example.com".isValidEmail
-"2024-01-15".toDate(format: "yyyy-MM-dd")
+"test@example.com".isValidEmail()
+"2024-01-15".toDate(stringFormat: "yyyy-MM-dd")
 
 // Number extensions
-1_234_567.abbreviated
+1_234_567.abbreviated()
 42.5.percentage()
 
 // Date extensions
@@ -407,8 +407,8 @@ import RKUtils
 
 func verifyRKUtils() {
     // Foundation
-    assert("test@example.com".isValidEmail == true)
-    assert(1000.abbreviated == "1K")
+    assert("test@example.com".isValidEmail() == true)
+    assert(1000.abbreviated() == "1K")
 
     // Platform-specific
     #if canImport(UIKit)

--- a/Sources/RKUtils/RKUtils.docc/Platform-Support.md
+++ b/Sources/RKUtils/RKUtils.docc/Platform-Support.md
@@ -10,15 +10,15 @@ RKUtils is designed to work across all Apple platforms with a unified API. Platf
 
 ### Minimum Versions
 
-| Platform | Minimum Version | Notes |
-|----------|----------------|-------|
-| **iOS** | 14.0 | Full UIKit support |
-| **macOS** | 11.0 (Big Sur) | Full AppKit support |
-| **tvOS** | 14.0 | Full UIKit support |
-| **watchOS** | 7.0 | Foundation only |
-| **visionOS** | 1.0 | Full UIKit support |
-| **Mac Catalyst** | 14.0 | Uses UIKit APIs |
-| **Linux** | N/A | Foundation only |
+| Platform         | Minimum Version | Notes               |
+| ---------------- | --------------- | ------------------- |
+| **iOS**          | 14.0            | Full UIKit support  |
+| **macOS**        | 11.0 (Big Sur)  | Full AppKit support |
+| **tvOS**         | 14.0            | Full UIKit support  |
+| **watchOS**      | 7.0             | Foundation only     |
+| **visionOS**     | 1.0             | Full UIKit support  |
+| **Mac Catalyst** | 14.0            | Uses UIKit APIs     |
+| **Linux**        | N/A             | Foundation only     |
 
 ### Development Requirements
 
@@ -31,17 +31,19 @@ RKUtils is designed to work across all Apple platforms with a unified API. Platf
 
 Available on **all platforms** including Linux:
 
-| Extension | iOS | macOS | tvOS | watchOS | visionOS | Linux |
-|-----------|-----|-------|------|---------|----------|-------|
-| String | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Date | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Int | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Double | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Bundle | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Data | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| ProcessInfo | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ Limited |
+| Extension   | iOS | macOS | tvOS | watchOS | visionOS | Linux      |
+| ----------- | --- | ----- | ---- | ------- | -------- | ---------- |
+| String      | ✅  | ✅    | ✅   | ✅      | ✅       | ✅         |
+| Date        | ✅  | ✅    | ✅   | ✅      | ✅       | ✅         |
+| Int         | ✅  | ✅    | ✅   | ✅      | ✅       | ✅         |
+| Double      | ✅  | ✅    | ✅   | ✅      | ✅       | ✅         |
+| URL         | ✅  | ✅    | ✅   | ✅      | ✅       | ✅         |
+| Bundle      | ✅  | ✅    | ✅   | ✅      | ✅       | ✅         |
+| Data        | ✅  | ✅    | ✅   | ✅      | ✅       | ✅         |
+| ProcessInfo | ✅  | ✅    | ✅   | ✅      | ✅       | ⚠️ Limited |
 
 **Linux Limitations:**
+
 - No `CLLocationCoordinate2D` (requires CoreLocation)
 - No measurement formatters (distance, speed, temperature, etc.)
 - No `RelativeDateTimeFormatter` for `Date.relativeTime()`
@@ -51,18 +53,18 @@ Available on **all platforms** including Linux:
 
 Available on iOS, tvOS, visionOS, and Mac Catalyst:
 
-| Extension | iOS | macOS | tvOS | watchOS | visionOS | Catalyst |
-|-----------|-----|-------|------|---------|----------|----------|
-| UIView | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| UIColor | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| UITextField | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| UITextView | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| UITableView | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| UICollectionView | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| UIDevice | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| UIScreen | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| UIStoryboard | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| CGRect | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Extension        | iOS | macOS | tvOS | watchOS | visionOS | Catalyst |
+| ---------------- | --- | ----- | ---- | ------- | -------- | -------- |
+| UIView           | ✅  | ❌    | ✅   | ❌      | ✅       | ✅       |
+| UIColor          | ✅  | ❌    | ✅   | ❌      | ✅       | ✅       |
+| UITextField      | ✅  | ❌    | ✅   | ❌      | ✅       | ✅       |
+| UITextView       | ✅  | ❌    | ❌   | ❌      | ✅       | ✅       |
+| UITableView      | ✅  | ❌    | ✅   | ❌      | ✅       | ✅       |
+| UICollectionView | ✅  | ❌    | ✅   | ❌      | ✅       | ✅       |
+| UIDevice         | ✅  | ❌    | ✅   | ❌      | ✅       | ✅       |
+| UIScreen         | ✅  | ❌    | ✅   | ❌      | ✅       | ✅       |
+| UIStoryboard     | ✅  | ❌    | ✅   | ❌      | ✅       | ✅       |
+| CGRect           | ✅  | ✅    | ✅   | ❌      | ✅       | ✅       |
 
 **Note:** Mac Catalyst uses UIKit APIs, not AppKit.
 
@@ -70,22 +72,22 @@ Available on iOS, tvOS, visionOS, and Mac Catalyst:
 
 Available on **macOS only** (not Mac Catalyst):
 
-| Extension | iOS | macOS | tvOS | watchOS | visionOS | Catalyst |
-|-----------|-----|-------|------|---------|----------|----------|
-| NSView | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| NSColor | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| NSTextField | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| NSSecureTextField | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| NSTableView | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| NSCollectionView | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Extension         | iOS | macOS | tvOS | watchOS | visionOS | Catalyst |
+| ----------------- | --- | ----- | ---- | ------- | -------- | -------- |
+| NSView            | ❌  | ✅    | ❌   | ❌      | ❌       | ❌       |
+| NSColor           | ❌  | ✅    | ❌   | ❌      | ❌       | ❌       |
+| NSTextField       | ❌  | ✅    | ❌   | ❌      | ❌       | ❌       |
+| NSSecureTextField | ❌  | ✅    | ❌   | ❌      | ❌       | ❌       |
+| NSTableView       | ❌  | ✅    | ❌   | ❌      | ❌       | ❌       |
+| NSCollectionView  | ❌  | ✅    | ❌   | ❌      | ❌       | ❌       |
 
 ### SwiftUI Extensions
 
 Available on **all Apple platforms** (requires SwiftUI framework):
 
 | Extension | iOS | macOS | tvOS | watchOS | visionOS | Linux |
-|-----------|-----|-------|------|---------|----------|-------|
-| Color | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| --------- | --- | ----- | ---- | ------- | -------- | ----- |
+| Color     | ✅  | ✅    | ✅   | ✅      | ✅       | ❌    |
 
 ## Platform-Specific Features
 
@@ -114,14 +116,17 @@ let cell = tableView.dequeueReusableCell(MyCell.self, for: indexPath)
 ```
 
 **iOS-Specific:**
+
 - `UITextView` extensions (not available on tvOS)
 - Full touch and gesture support
 
 **tvOS-Specific:**
+
 - Focus engine considerations
 - Remote control support
 
 **visionOS-Specific:**
+
 - Spatial UI considerations
 - Same APIs as iOS
 
@@ -172,7 +177,7 @@ watchOS only has Foundation and SwiftUI support:
 import RKUtils
 
 // Foundation extensions work
-let formatted = 1234.abbreviated  // "1.2K"
+let formatted = 1234.abbreviated()()  // "1.2K"
 let valid = "test@example.com".isValidEmail  // true
 
 // SwiftUI Color works
@@ -191,7 +196,7 @@ import RKUtils
 
 // ✅ Available
 "test@example.com".isValidEmail
-1234.abbreviated
+1234.abbreviated()
 Date().toString()
 
 // ❌ Not available
@@ -384,7 +389,7 @@ import Foundation
 import RKUtils
 
 // Use Foundation everywhere
-let formatted = 1234.abbreviated
+let formatted = 1234.abbreviated()()
 
 // Platform-specific when needed
 #if canImport(UIKit)
@@ -459,6 +464,7 @@ let color = NSColor(hexString: "#FF5733")
 ```
 
 **Differences:**
+
 - `UIColor` → `NSColor`
 - `UIView` → `NSView`
 - `UITextField` → `NSTextField`

--- a/Sources/RKUtils/RKUtils.docc/Platform-Support.md
+++ b/Sources/RKUtils/RKUtils.docc/Platform-Support.md
@@ -177,8 +177,8 @@ watchOS only has Foundation and SwiftUI support:
 import RKUtils
 
 // Foundation extensions work
-let formatted = 1234.abbreviated()()  // "1.2K"
-let valid = "test@example.com".isValidEmail  // true
+let formatted = 1234.abbreviated()  // "1.2K"
+let valid = "test@example.com".isValidEmail()  // true
 
 // SwiftUI Color works
 Color(hexString: "#FF5733")
@@ -195,7 +195,7 @@ Linux support is limited to Foundation types:
 import RKUtils
 
 // ✅ Available
-"test@example.com".isValidEmail
+"test@example.com".isValidEmail()
 1234.abbreviated()
 Date().toString()
 

--- a/Sources/RKUtils/RKUtils.docc/QuickStart.md
+++ b/Sources/RKUtils/RKUtils.docc/QuickStart.md
@@ -34,27 +34,27 @@ These work on **all platforms** including iOS, macOS, tvOS, watchOS, visionOS, a
 import RKUtils
 
 let email = "user@example.com"
-if email.isValidEmail {
+if email.isValidEmail() {
     print("Valid email address")
 }
 
 // Invalid examples
-"@example.com".isValidEmail        // false
-"user@".isValidEmail               // false
-"not an email".isValidEmail        // false
+"@example.com".isValidEmail()        // false
+"user@".isValidEmail()               // false
+"not an email".isValidEmail()        // false
 ```
 
 #### Date Parsing from Strings
 
 ```swift
 let dateString = "2024-01-15"
-if let date = dateString.toDate(format: "yyyy-MM-dd") {
+if let date = dateString.toDate(stringFormat: "yyyy-MM-dd") {
     print("Parsed date: \(date)")
 }
 
 // ISO8601 parsing
 let isoString = "2024-01-15T10:30:00Z"
-if let isoDate = isoString.toISO8601Date() {
+if let isoDate = isoString.iso8601Date() {
     print("ISO date: \(isoDate)")
 }
 ```
@@ -63,19 +63,13 @@ if let isoDate = isoString.toISO8601Date() {
 
 ```swift
 let text = "Hello, World!"
-let encoded = text.base64Encoded
-print(encoded)  // "SGVsbG8sIFdvcmxkIQ=="
-
-if let decoded = encoded.base64Decoded {
-    print(decoded)  // "Hello, World!"
-}
+let encoded = text.toBase64  // "SGVsbG8sIFdvcmxkIQ=="
 ```
 
-#### Digit and Word Conversion
+#### Digit Names
 
 ```swift
-"123".digitNames        // "one two three"
-"ABC 123".digitNames    // "ABC one two three"
+123.digitNames()   // ["one", "two", "three"]
 ```
 
 ### Number Extensions
@@ -86,30 +80,30 @@ if let decoded = encoded.base64Decoded {
 import RKUtils
 
 // Abbreviations
-1_000.abbreviated       // "1K"
-1_234_567.abbreviated   // "1.2M"
-2_500_000_000.abbreviated  // "2.5B"
+1_000.abbreviated()       // "1K"
+1_234_567.abbreviated()   // "1.2M"
+2_500_000_000.abbreviated()  // "2.5B"
 
 // Locale-specific formatting
 let number = 1234
 number.toLocal()  // "1,234" (en_US) or "1 234" (fr_FR)
 
 // Pluralization
-1.pluralized(singular: "apple")           // "1 apple"
-2.pluralized(singular: "apple")           // "2 apples"
-2.pluralized(singular: "child", plural: "children")  // "2 children"
+1.pluralized("apple")              // "1 apple"
+2.pluralized("apple")              // "2 apples"
+2.pluralized("child", "children")  // "2 children"
 
 // Byte sizes
-1024.byteSizeFormatted       // "1.0 KB"
-1_048_576.byteSizeFormatted  // "1.0 MB"
+1024.byteSizeFormatted()       // "1 KB"
+1_048_576.byteSizeFormatted()  // "1 MB"
 ```
 
 #### Double Formatting
 
 ```swift
 // Percentages
-0.75.percentage()        // "75%"
-0.4567.percentage()      // "45.67%"
+75.0.percentage()        // "75%"
+45.67.percentage()       // "45.67%"
 
 // Currency
 99.99.currency(code: "USD")  // "$99.99"
@@ -119,7 +113,7 @@ number.toLocal()  // "1,234" (en_US) or "1 234" (fr_FR)
 123456.78.scientificNotation()  // "1.23e+05"
 
 // Rounding
-3.14159.roundedString(places: 2)  // "3.14"
+3.14159.roundedString(toPlaces: 2)  // "3.14"
 
 // Measurements (Darwin only)
 42.0.distance()      // "42 km"
@@ -202,7 +196,7 @@ import RKUtils
 // Version information
 let version = Bundle.main.releaseVersionNumber  // "1.0.0"
 let build = Bundle.main.buildVersionNumber      // "42"
-let pretty = Bundle.main.releaseVersionNumberPretty  // "1.0.0 (42)"
+let pretty = Bundle.main.releaseVersionNumberPretty  // "v1.0.0"
 
 // App name
 let appName = Bundle.main.bundleDisplayName  // "MyApp"
@@ -382,7 +376,7 @@ class MyViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        textField.textPublisher
+        textField.textPublisher()
             .sink { text in
                 print("Text changed: \(text)")
             }
@@ -509,7 +503,7 @@ class MyViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        textField.textPublisher
+        textField.textPublisher()
             .sink { text in
                 print("Text changed: \(text)")
             }
@@ -695,7 +689,7 @@ class StatsViewController: NSViewController {
 
         setupStatsCard(
             title: "Total Users",
-            value: 1_234_567.abbreviated,  // "1.2M"
+            value: 1_234_567.abbreviated(),  // "1.2M"
             color: NSColor(hexString: "#007AFF")
         )
     }
@@ -773,7 +767,7 @@ struct LoginForm: View {
     var body: some View {
         TextField("Email", text: $email)
             .onChange(of: email) { newValue in
-                isValid = newValue.isValidEmail
+                isValid = newValue.isValidEmail()
             }
 
         if !isValid && !email.isEmpty {

--- a/Sources/RKUtils/RKUtils.docc/RKUtils.md
+++ b/Sources/RKUtils/RKUtils.docc/RKUtils.md
@@ -21,9 +21,9 @@ RKUtils provides battle-tested utilities for Foundation, UIKit, AppKit, and Swif
 import RKUtils
 
 // Foundation utilities work everywhere
-"test@example.com".isValidEmail  // true
-"2024-01-15".toDate(format: "yyyy-MM-dd")
-1_234_567.abbreviated  // "1.2M"
+"test@example.com".isValidEmail()  // true
+"2024-01-15".toDate(stringFormat: "yyyy-MM-dd")
+1_234_567.abbreviated()  // "1.2M"
 
 // UIKit (iOS, tvOS, visionOS)
 #if canImport(UIKit)
@@ -66,6 +66,7 @@ Cross-platform utilities that work on all Apple platforms.
 - ``Swift/Double``
 - ``Foundation/Bundle``
 - ``Foundation/Data``
+- ``Foundation/URL``
 - ``Foundation/ProcessInfo``
 
 ### UIKit Extensions

--- a/Tests/RKUtilsTests/Foundation/DoubleExtensionsTests.swift
+++ b/Tests/RKUtilsTests/Foundation/DoubleExtensionsTests.swift
@@ -71,7 +71,7 @@ import Testing
 
     @Test("abbreviated formats numbers with K, M, B suffixes")
     func abbreviated() {
-        #expect(999.0.abbreviated() == "999.0")
+        #expect(999.0.abbreviated() == "999")
         #expect(1_200.0.abbreviated().contains("1") && 1_200.0.abbreviated().contains("K"))
         #expect(1_500_000.0.abbreviated().contains("1") && 1_500_000.0.abbreviated().contains("M"))
         #expect(2_500_000_000.0.abbreviated().contains("2") && 2_500_000_000.0.abbreviated().contains("B"))
@@ -334,7 +334,7 @@ import Testing
 
     @Test("zero is handled correctly across methods")
     func zero() {
-        #expect(0.0.abbreviated() == "0.0")
+        #expect(0.0.abbreviated() == "0")
         #expect(0.0.isWholeNumber)
         #expect(0.0.signString == "")
     }

--- a/Tests/RKUtilsTests/Foundation/StringExtensionsTests.swift
+++ b/Tests/RKUtilsTests/Foundation/StringExtensionsTests.swift
@@ -169,48 +169,20 @@ struct StringExtensionsTests {
 
     // MARK: - File I/O Tests
 
-    @Test("Write and read file")
-    func writeAndReadFile() throws {
+    @Test("Write to file")
+    func writeToFile() throws {
         let testString = "Test content for file I/O"
         let tempDirectory = FileManager.default.temporaryDirectory
         let fileURL = tempDirectory.appendingPathComponent("test_file.txt")
 
-        // Clean up if file exists
         try? FileManager.default.removeItem(at: fileURL)
-
-        // Write to file
         testString.writeToFile(saveLocation: fileURL)
-
-        // Verify file exists
         #expect(FileManager.default.fileExists(atPath: fileURL.path))
-
-        // Read from file
-        let readString = "".readFromFile(fileURL: fileURL)
-        #expect(readString != nil)
-        #expect(readString == testString)
-
-        // Clean up
         try? FileManager.default.removeItem(at: fileURL)
-    }
-
-    @Test("Read from non-existent file returns nil")
-    func readFromNonExistentFile() {
-        let tempDirectory = FileManager.default.temporaryDirectory
-        let nonExistentURL = tempDirectory.appendingPathComponent("non_existent_file.txt")
-
-        let readString = "".readFromFile(fileURL: nonExistentURL)
-        #expect(readString == nil)
     }
 
     @Test("Write to nil URL does not crash")
     func writeToNilURL() {
-        // Should not crash
         "test".writeToFile(saveLocation: nil)
-    }
-
-    @Test("Read from nil URL returns nil")
-    func readFromNilURL() {
-        let result = "".readFromFile(fileURL: nil)
-        #expect(result == nil)
     }
 }

--- a/Tests/RKUtilsTests/Foundation/URLExtensionsTests.swift
+++ b/Tests/RKUtilsTests/Foundation/URLExtensionsTests.swift
@@ -1,0 +1,37 @@
+//
+//  URLExtensionsTests.swift
+//  RKUtils
+//
+//  Created by Rakibur Khan on 2/4/24.
+//
+
+import Testing
+import Foundation
+@testable import RKUtils
+
+@Suite("URL Extensions")
+struct URLExtensionsTests {
+
+    // MARK: - readFromFile
+
+    @Test("Read from file returns content")
+    func readFromFileReturnsContent() throws {
+        let testString = "Test content for file I/O"
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("rkutils_test_read.txt")
+
+        try? FileManager.default.removeItem(at: fileURL)
+        testString.writeToFile(saveLocation: fileURL)
+
+        let result = fileURL.readFromFile()
+        #expect(result == testString)
+
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    @Test("Read from non-existent file returns nil")
+    func readFromNonExistentFileReturnsNil() {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("rkutils_no_such_file.txt")
+        try? FileManager.default.removeItem(at: fileURL)
+        #expect(fileURL.readFromFile() == nil)
+    }
+}


### PR DESCRIPTION
- **New `URL.readFromFile()`** — file reading moved from `String` (where `self` was unused) to `URL` (the natural owner). `String.readFromFile(fileURL:)` removed.
- **Unified `abbreviated(locale:decimalPlaces:)`** — `Int` now delegates to `Double`, eliminating duplicate logic and fixing the negative-number bug in the old `Int` implementation. New `decimalPlaces` parameter lets callers control decimal precision (default `1`).
- **`Int.inWords` delegates to `Double.inWords`** — same single-implementation pattern; consistent behaviour across both types.
- **Doc audit** — fixed phantom symbol links, wrong method names, and missing `()` call syntax across `QuickStart.md`, `Migration-Guide.md`, `Platform-Support.md`, and all extension `.md` files.

## Breaking Changes

- `String.readFromFile(fileURL:)` removed. Replace with `fileURL.readFromFile()`.

## Migration

```swift
// Before
let content = "".readFromFile(fileURL: myURL)

// After
let content = myURL.readFromFile()
```

```swift
// New decimalPlaces parameter (backward compatible — default is 1)
1_234.abbreviated()                          // "1.2K" (unchanged)
1_234.abbreviated(decimalPlaces: 0)          // "1K"
1_234_567.abbreviated(decimalPlaces: 2)      // "1.23M"
```

## Test Plan

- [ ] `swift test` passes on macOS (all 194+ tests)
- [ ] `swift test` passes on Linux via Docker (`docker run --rm -v "$PWD:/workspace" swift:6.0 bash -c "cd /workspace && swift test"`)
- [ ] `URL.readFromFile()` returns file content for valid URL, `nil` for missing file
- [ ] `abbreviated(decimalPlaces:)` produces correct output for K / M / B thresholds and negative values
- [ ] No regressions in `Int.inWords`, `Double.inWords`, or `percentage`
